### PR TITLE
FIX: file_name in demographics distribution query

### DIFF
--- a/app/bunny/core/query_solvers.py
+++ b/app/bunny/core/query_solvers.py
@@ -488,7 +488,7 @@ def solve_distribution(
         result_file = File(
             data=res_b64,
             description="Result of code.distribution anaylsis",
-            name=DISTRIBUTION_TYPE_FILE_NAMES_MAP.get(query.analysis, ""),
+            name=DISTRIBUTION_TYPE_FILE_NAMES_MAP.get(query.code, ""),
             sensitive=True,
             reference="",
             size=size,

--- a/app/bunny/test/test_demographics_distribution_query.py
+++ b/app/bunny/test/test_demographics_distribution_query.py
@@ -1,0 +1,84 @@
+import pytest
+from core.query_solvers import DistributionQuery, solve_distribution
+from core.db_manager import SyncDBManager
+from core.rquest_dto.result import RquestResult
+from core.rquest_dto.file import File
+from dotenv import load_dotenv
+import os
+import core.settings as settings
+
+load_dotenv()
+
+
+@pytest.fixture
+def db_manager():
+    datasource_db_port = os.getenv("DATASOURCE_DB_PORT")
+    return SyncDBManager(
+        username=os.getenv("DATASOURCE_DB_USERNAME"),
+        password=os.getenv("DATASOURCE_DB_PASSWORD"),
+        host=os.getenv("DATASOURCE_DB_HOST"),
+        port=(int(datasource_db_port) if datasource_db_port is not None else None),
+        database=os.getenv("DATASOURCE_DB_DATABASE"),
+        drivername=os.getenv("DATASOURCE_DB_DRIVERNAME", settings.DEFAULT_DB_DRIVER),
+        schema=os.getenv("DATASOURCE_DB_SCHEMA"),
+    )
+
+
+@pytest.fixture
+def distribution_query():
+    return DistributionQuery(
+        owner="user1", 
+        code="DEMOGRAPHICS",
+        analysis="DISTRIBUTION",
+        uuid="unique_id", 
+        collection="collection_id"
+        
+    )
+
+
+@pytest.fixture
+def distribution_example():
+    return RquestResult(
+        uuid="unique_id",
+        status="ok",
+        collection_id="collection_id",
+        count=1,
+        datasets_count=1,
+        files=[File(
+             name="demographics.distribution",
+             data="",
+             description="Result of code.distribution anaylsis",
+             size=0.308,
+             type_="BCOS",
+             sensitive=True,
+             reference=""
+             )
+        ],
+        message="",
+        protocol_version="v2",
+    )
+
+
+@pytest.fixture
+def distribution_result(db_manager, distribution_query):
+    db_manager.list_tables()
+    return solve_distribution(db_manager=db_manager, query=distribution_query)
+
+def test_solve_distribution_returns_result(distribution_result):
+    assert isinstance(distribution_result, RquestResult)
+
+def test_solve_distribution_is_ok(distribution_result):
+    assert distribution_result.status == "ok"
+
+def test_solve_distribution_files_count(distribution_result):
+    assert len(distribution_result.files) == 1
+
+def test_solve_distribution_files_type(distribution_result):
+    assert isinstance(distribution_result.files[0], File)
+
+def test_solve_distribution_match_query(distribution_result, distribution_example):
+    assert distribution_result.files[0].name == distribution_example.files[0].name
+    assert distribution_result.files[0].type_ == distribution_example.files[0].type_
+    assert distribution_result.files[0].description == distribution_example.files[0].description
+    assert distribution_result.files[0].sensitive == distribution_example.files[0].sensitive
+    assert distribution_result.files[0].reference == distribution_example.files[0].reference


### PR DESCRIPTION
<!--
INSTRUCTIONS:

1. Please complete all sections detailing an ACTION
2. All tasks must be checked off before merging
-->

<!--
  PR Guidance:
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

<!-- 
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->


## Pull Request Contents

🦋 Bug Fix

## Description

Fixes populating file name in results for a Demographics Distribution query. 
Adds tests for Demographics Distribution Query

## Related Issues or other material

- [x] This PR relates to one or more issues, detailed below

- Related Health-Informatics-UoN/hutch-bunny#8 
- Closes Health-Informatics-UoN/hutch-bunny#14 

## ✅ Added/updated tests?

- [x] This PR contains relevant tests

- [x] I've completed all **actions** and **tasks** detailed in the PR Template
